### PR TITLE
feat: add Dockerfile

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,43 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PASS }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ secrets.DOCKER_HUB_REPOSITORY }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# First, we need an image to build the application
+FROM rust:slim-bullseye as builder
+
+WORKDIR /usr/src/hms-mqtt-publish
+
+# We only copy the files we need. Otherwise the git folders caused an error in the arm/v7 build .
+COPY src src
+COPY build.rs .
+COPY Cargo.toml .
+
+# Compile the application and install it
+RUN cargo install --path .
+
+# Then we use a small base image and copy the compiled application into this image. This way we get a small image without overheating the build environment. 
+FROM debian:bullseye-slim
+
+# Copy the installed application from the build image to the smaller image.
+COPY --from=builder /usr/local/cargo/bin/hms-mqtt-publish /usr/local/bin/hms-mqtt-publish
+
+# Run the application with given env variables
+CMD hms-mqtt-publish $INVERTER_HOST $MQTT_BROKER_HOST $MQTT_USERNAME $MQTT_PASSWORD


### PR DESCRIPTION
The Dockerfile has been added to create a Docker image. Use the following command to do this and push it to docker hub:
`docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t <your docker hub id>/hms-mqtt-publisher:<version> --push .`
