### PR TITLE
Feature: Auto publish docker image to docker hub

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,40 @@
+name: Publish multi platform Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platform: "arm64,arm"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PASS }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ secrets.DOCKER_HUB_REPOSITORY }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# First, we need an image to build the application
+FROM rust:slim-bullseye as builder
+
+WORKDIR /usr/src/hms-mqtt-publish
+
+# We only copy the files we need. Otherwise the git folders caused an error in the arm/v7 build .
+COPY src src
+COPY build.rs .
+COPY Cargo.toml .
+
+# Compile the application and install it
+RUN cargo install --path .
+
+# Then we use a small base image and copy the compiled application into this image. This way we get a small image without overheating the build environment. 
+FROM debian:bullseye-slim
+
+# Copy the installed application from the build image to the smaller image.
+COPY --from=builder /usr/local/cargo/bin/hms-mqtt-publish /usr/local/bin/hms-mqtt-publish
+
+# Run the application with given env variables
+CMD hms-mqtt-publish $INVERTER_HOST $MQTT_BROKER_HOST $MQTT_USERNAME $MQTT_PASSWORD

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ FROM debian:bullseye-slim
 COPY --from=builder /usr/local/cargo/bin/hms-mqtt-publish /usr/local/bin/hms-mqtt-publish
 
 # Run the application with given env variables
-CMD hms-mqtt-publish $INVERTER_HOST $MQTT_BROKER_HOST $MQTT_USERNAME $MQTT_PASSWORD
+CMD hms-mqtt-publish $INVERTER_HOST $MQTT_BROKER_HOST $MQTT_USERNAME $MQTT_PASSWORD $MQTT_PORT


### PR DESCRIPTION
This branch adds the function to automatically create multi-platform images and transfer them to Docker Hub. It uses the git hub action for this.
You only need to set the following secrets in git hub:
```
DOCKER_HUB_USER
DOCKER_HUB_PASS
DOCKER_HUB_NAMESPACE
DOCKER_HUB_REPOSITORY 
```
The action is triggered by the creation of a release in git hub. It uses the release version to publish it in Docker Hub. The latest version is also automatically set to this new version.

**Resolve DennisOSRM/hms-mqtt-publisher#6**