### PR TITLE
Publish more state information of the inverter to MQTT

### DIFF
--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -48,29 +48,60 @@ impl MetricCollector for Mqtt {
     fn publish(&mut self, hms_state: &HMSStateResponse) {
         debug!("{hms_state}");
 
+        self.client.subscribe("hms800wt2", QoS::AtMostOnce).unwrap();
+
         let pv_current_power = hms_state.pv_current_power as f32 / 10.;
         let pv_daily_yield = hms_state.pv_daily_yield;
+        let pv_grid_voltage = hms_state.inverter_state[0].grid_voltage as f32 / 10.;
+        let pv_grid_freq = hms_state.inverter_state[0].grid_freq as f32 / 100.;
+        let pv_inv_temperature = hms_state.inverter_state[0].temperature as f32 / 10.;
+        let pv_port1_voltage = hms_state.port_state[0].pv_vol as f32 / 10.;
+        let pv_port1_curr = hms_state.port_state[0].pv_cur as f32 / 100.;
+        let pv_port1_power = hms_state.port_state[0].pv_power as f32 / 10.;
+        let pv_port1_energy = hms_state.port_state[0].pv_energy_total as f32 / 10.;
+        let pv_port1_daily_yield = hms_state.port_state[0].pv_daily_yield as f32 / 10.;
+        let pv_port2_voltage = hms_state.port_state[1].pv_vol as f32 / 10.;
+        let pv_port2_curr = hms_state.port_state[1].pv_cur as f32 / 100.;
+        let pv_port2_power = hms_state.port_state[1].pv_power as f32 / 10.;
+        let pv_port2_energy = hms_state.port_state[1].pv_energy_total as f32 / 10.;
+        let pv_port2_daily_yield = hms_state.port_state[1].pv_daily_yield as f32 / 10.;
 
-        self.client
-            .subscribe("hms800wt2/pv_current_power", QoS::AtMostOnce)
-            .unwrap();
-        match self.client.publish(
-            "hms800wt2/pv_current_power",
-            QoS::AtMostOnce,
-            true,
-            pv_current_power.to_string(),
-        ) {
-            Ok(_) => {}
-            Err(e) => warn!("mqtt error: {e}"),
-        }
-        match self.client.publish(
-            "hms800wt2/pv_daily_yield",
-            QoS::AtMostOnce,
-            true,
-            pv_daily_yield.to_string(),
-        ) {
-            Ok(_) => {}
-            Err(e) => warn!("mqtt error: {e}"),
-        }
+        // TODO: this section bears a lot of repetition. Investigate if there's a more idiomatic way to get the same result, perhaps using a macro
+        let topic_payload_pairs = [
+            ("hms800wt2/pv_current_power", pv_current_power.to_string()),
+            ("hms800wt2/pv_daily_yield", pv_daily_yield.to_string()),
+            ("hms800wt2/pv_current_power", pv_current_power.to_string()),
+            ("hms800wt2/pv_daily_yield", pv_daily_yield.to_string()),
+            ("hms800wt2/pv_grid_voltage", pv_grid_voltage.to_string()),
+            ("hms800wt2/pv_grid_freq", pv_grid_freq.to_string()),
+            (
+                "hms800wt2/pv_inv_temperature",
+                pv_inv_temperature.to_string(),
+            ),
+            ("hms800wt2/pv_port1_voltage", pv_port1_voltage.to_string()),
+            ("hms800wt2/pv_port1_curr", pv_port1_curr.to_string()),
+            ("hms800wt2/pv_port1_power", pv_port1_power.to_string()),
+            ("hms800wt2/pv_port1_energy", pv_port1_energy.to_string()),
+            (
+                "hms800wt2/pv_port1_daily_yield",
+                pv_port1_daily_yield.to_string(),
+            ),
+            ("hms800wt2/pv_port2_voltage", pv_port2_voltage.to_string()),
+            ("hms800wt2/pv_port2_curr", pv_port2_curr.to_string()),
+            ("hms800wt2/pv_port2_power", pv_port2_power.to_string()),
+            ("hms800wt2/pv_port2_energy", pv_port2_energy.to_string()),
+            (
+                "hms800wt2/pv_port2_daily_yield",
+                pv_port2_daily_yield.to_string(),
+            ),
+        ];
+
+        topic_payload_pairs
+            .into_iter()
+            .for_each(|(topic, payload)| {
+                if let Err(e) = self.client.publish(topic, QoS::AtMostOnce, true, payload) {
+                    warn!("mqtt error: {e}")
+                }
+            });
     }
 }


### PR DESCRIPTION
Implements the suggestion mentioned in https://github.com/lumapu/ahoy/issues/1189#issuecomment-1817546010, thx @ckmde in idiomatic Rust. Closes #14 

- [ ] test against running device and MQTT instance