### PR TITLE
Staged docker builds

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -13,8 +13,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        with:
-          platform: "arm64,arm"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to Docker Hub
@@ -38,3 +36,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ FROM rust:slim-bullseye as builder
 
 WORKDIR /usr/src/hms-mqtt-publish
 
-# The following builds the rust application in three stages:
+# The following builds the rust application in two stages:
 #
 # 1. Build the dependencies
-# 2. Build the protobuf files
-# 3. Build the application
+# 2. Build the application
 # 
 # This way, each stage is cached and rebuilding the application is faster.
 
@@ -22,21 +21,7 @@ RUN mkdir src && \
 
 # Stage 2: Build the protobuf files
 
-RUN mkdir src/protos
-# Copy build.rs and Protobuf files
 COPY ./build.rs ./
-COPY ./src/protos/*.proto ./src/protos/
-
-# Run the build script to generate code from Protobuf files
-RUN echo "fn main() {println!(\"hello from protbuf build\")}" > src/main.rs && \
-    cargo build --release
-
-
-# Stage 3: Compile the application and install it
-
-# This touch command is important to ensure that the build.rs is considered changed
-RUN touch build.rs
-# Now copy the actual source code and re-compile
 COPY ./src ./src
 RUN cargo install --path .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,45 @@ FROM rust:slim-bullseye as builder
 
 WORKDIR /usr/src/hms-mqtt-publish
 
-# We only copy the files we need. Otherwise the git folders caused an error in the arm/v7 build .
-COPY src src
-COPY build.rs .
-COPY Cargo.toml .
+# The following builds the rust application in three stages:
+#
+# 1. Build the dependencies
+# 2. Build the protobuf files
+# 3. Build the application
+# 
+# This way, each stage is cached and rebuilding the application is faster.
 
-# Compile the application and install it
+
+# Stage 1: Build the dependencies
+
+COPY ./Cargo.toml ./
+RUN mkdir src && \
+    echo "fn main() {println!(\"hello from dependency build\")}" > src/main.rs && \
+    cargo build --release
+
+
+# Stage 2: Build the protobuf files
+
+RUN mkdir src/protos
+# Copy build.rs and Protobuf files
+COPY ./build.rs ./
+COPY ./src/protos/*.proto ./src/protos/
+
+# Run the build script to generate code from Protobuf files
+RUN echo "fn main() {println!(\"hello from protbuf build\")}" > src/main.rs && \
+    cargo build --release
+
+
+# Stage 3: Compile the application and install it
+
+# This touch command is important to ensure that the build.rs is considered changed
+RUN touch build.rs
+# Now copy the actual source code and re-compile
+COPY ./src ./src
 RUN cargo install --path .
+
+# Copy the installed application from the build image to the smaller image.
+RUN cp /usr/local/cargo/bin/hms-mqtt-publish /usr/local/bin/hms-mqtt-publish
 
 # Then we use a small base image and copy the compiled application into this image. This way we get a small image without overheating the build environment. 
 FROM debian:bullseye-slim


### PR DESCRIPTION
During the development of the home assistant addon, I had the problem that building the dockerfile took a long time to complete since it always needed to build all dependencies from scratch.

This PR splits compilation of the rust application into 3 stages:

  1. building the dependencies
  2. building the Protobuf files
  3. building the actual application source code

and adds caching support to the github workflow. Each stage / layer will then only need to be recompiled when their dependencies change, reducing the build time from almost an hour to just a few of minutes for minor code changes (In my experience, <1 minute on my home assistant pi4, <5 minutes for the workflow).

I also removed the "platform" argument in the qemu step of the workflow since it probably isn't necessary and didn't have any effect anyway (would need to be renamed to "platforms" to take effect)
