### PR TITLE
Implement output channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ rumqttc = "0.23.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hostname = "0.3.1"
+toml = "0.8.8"
+serde_derive = "1.0.193"
 
 [build-dependencies]
 protobuf-codegen = "3.3.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,8 @@ FROM debian:bullseye-slim
 # Copy the installed application from the build image to the smaller image.
 COPY --from=builder /usr/local/cargo/bin/hms-mqtt-publish /usr/local/bin/hms-mqtt-publish
 
-# Run the application with given env variables
-CMD hms-mqtt-publish $INVERTER_HOST $MQTT_BROKER_HOST $MQTT_USERNAME $MQTT_PASSWORD $MQTT_PORT
+# Generate the config file from given environment variables
+RUN echo "inverter_host = \"$INVERTER_HOST\" \n\n[home_assistent] \nhost = \"$MQTT_BROKER_HOST\"\nusername = \"$MQTT_USERNAME\"\npassword = \"$MQTT_PASSWORD\"\nport = $MQTT_PORT\n" > config.toml
+
+# Run the application
+CMD hms-mqtt-publish

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hms-mqtt-publisher
 
-This tool fetches the current telemetry information from the HMS-XXXXW-T2 series of micro-inverters and publishes the information into an MQTT broker. Please note that it doesn’t implement a DTU, but pulls the information off the internal DTU of these inverters. 
+This tool fetches the current telemetry information from the HMS-XXXXW-2T series of micro-inverters and publishes the information into an MQTT broker. Please note that it doesn’t implement a DTU, but pulls the information off the internal DTU of these inverters. 
 
 ## How to run
 The tool is distributed as source only — for now. You’ll have to download, compile and run it yourself. 
@@ -32,5 +32,5 @@ Please note: The tool does not come with any guarantees and if by chance you fry
 ## Known limitations
 - One can only fetch updates approximately twice per minute. The inverter firmware seems to implement a mandatory wait period of a little more than 30 seconds. If one makes a request within 30 seconds of the previous one, then the inverter will reply with the previous reading and restart the countdown. It will also not send updated values to S-Miles Cloud if this happens. 
 - The tool is a CLI tool and not a background service. 
-- The tools was developed for (and with an) HMS-800W-T2. It may work with the other inverters from the series, but is untested at the time of writing
+- The tools was developed for (and with an) HMS-800W-2T. It may work with the other inverters from the series, but is untested at the time of writing
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 This tool fetches the current telemetry information from the HMS-XXXXW-2T series of micro-inverters and publishes the information into an MQTT broker. Please note that it doesn’t implement a DTU, but pulls the information off the internal DTU of these inverters. 
 
 ## How to run
-The tool is distributed as source only — for now. You’ll have to download, compile and run it yourself. 
+The tool is distributed as source only — for now. You’ll have to download, compile and run it yourself. Please note that configuration of hosts, and passwords is done via `config.toml` from the current directory. It supports two different output channels. One is a simple MQTT publisher that doesn't follow a particular schema, and the other is made for [Home Assistant](https://www.home-assistant.io). It supports auto discovery of devices.
 
 ```
 $ git clone https://github.com/DennisOSRM/hms-mqtt-publisher.git
 $ cd hms-mqtt-publisher
-$ cargo r --release [inverter] [mqtt broker] [mqtt user] [mqtt password] [optional:mqtt port]
+$ cargo r
 ```
 ![image](https://github.com/lumapu/ahoy/assets/1067895/32c0b9b6-5aea-41e3-b9f8-161ce82fb99a)
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,12 @@
+inverter_host = "192.168.4.182"
+
+[home_assistent]
+host = "192.168.178.250"
+username = "mqttuser"
+password = "MqttPass1"
+port = 1883
+
+[simple_mqtt]
+host = "192.168.178.250"
+username = "mqttuser"
+password = "MqttPass1"

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 inverter_host = "192.168.4.182"
 
-[home_assistent]
+[home_assistant]
 host = "192.168.178.250"
 username = "mqttuser"
 password = "MqttPass1"

--- a/ha-hoymiles-wifi-addon/Dockerfile
+++ b/ha-hoymiles-wifi-addon/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM
 
 # Use pre-built image to copy the binary from
-FROM dennisosrm/hms-mqtt-publisher:v0.1 AS builder
+FROM dominikandreas/hms-mqtt-publisher-nightly:experimental-output_channels AS builder
 
 FROM $BUILD_FROM
 

--- a/ha-hoymiles-wifi-addon/config.yaml
+++ b/ha-hoymiles-wifi-addon/config.yaml
@@ -3,7 +3,7 @@ name: Hoymiles HMS Wifi Addon
 version: '0.1'
 slug: ha-hoymiles-wifi-addon
 description: Publishes telemetry information from Hoymiles HMS-XXXXW-T2 micro-inverters to your home assistant MQTT broker
-url: https://github.com/dominikandreas/hms-mqtt-publisher/tree/master/ha-hoymiles-wifi-addon
+url: https://github.com/dennisosrm/hms-mqtt-publisher/tree/master/ha-hoymiles-wifi-addon
 init: false
 arch:                              # List of supported architectures.
   - armv7

--- a/ha-hoymiles-wifi-addon/run.sh
+++ b/ha-hoymiles-wifi-addon/run.sh
@@ -47,15 +47,16 @@ if [[ -n "$MQTT_USERNAME" ]]; then
   echo "username = \"$MQTT_USERNAME\"\n" >> ./config.toml
 fi
 
-# Write mqtt broker password if specified
-if [[ -n "$MQTT_PASSWORD" ]]; then
-  echo "password = \"$MQTT_PASSWORD\"\n" >> /usr/local/bin/config.toml
-fi
+# Create the configuration file
+cat <<EOF > ./config.toml
+inverter_host = "$INVERTER_HOST"
 
-# Write port if specified
-if [[ -n "$MQTT_PORT" ]]; then
-  echo "port = $MQTT_PORT\n" >> /usr/local/bin/config.toml
-fi
+[home_assistant]
+host = "$MQTT_BROKER_HOST"
+username = "$MQTT_USERNAME"
+password = "$MQTT_PASSWORD"
+port = $MQTT_PORT
+EOF
 
 # Execute the application
 /usr/local/bin/hms-mqtt-publish

--- a/ha-hoymiles-wifi-addon/run.sh
+++ b/ha-hoymiles-wifi-addon/run.sh
@@ -31,15 +31,20 @@ if [[ -z "$MQTT_BROKER_HOST" ]]; then
   exit 1
 fi
 
-# The host names are mandatory information
-echo "inverter_host = \"$INVERTER_HOST\" \n\
-\n\
-[home_assistent] \n\
-host = \"$MQTT_BROKER_HOST\"\n"
+# Create the configuration file
+cat <<EOF > ./config.toml
+inverter_host = "$INVERTER_HOST"
+
+[home_assistent]
+host = "$MQTT_BROKER_HOST"
+username = "$MQTT_USERNAME"
+password = "$MQTT_PASSWORD"
+port = $MQTT_PORT
+EOF
 
 # Write mqtt broker username if specified
 if [[ -n "$MQTT_USERNAME" ]]; then
-  echo "username = \"$MQTT_USERNAME\"\n" >> /usr/local/bin/config.toml
+  echo "username = \"$MQTT_USERNAME\"\n" >> ./config.toml
 fi
 
 # Write mqtt broker password if specified

--- a/ha-hoymiles-wifi-addon/run.sh
+++ b/ha-hoymiles-wifi-addon/run.sh
@@ -31,23 +31,23 @@ if [[ -z "$MQTT_BROKER_HOST" ]]; then
   exit 1
 fi
 
-if [[ -z "$MQTT_USERNAME" ]]; then
-  echo "The mqtt_username is not configured."
-  exit 1
-fi
-
-if [[ -z "$MQTT_PASSWORD" ]]; then
-  echo "The mqtt_password is not configured."
-  exit 1
-fi
-
-# Write configuration to config.toml
+# The host names are mandatory information
 echo "inverter_host = \"$INVERTER_HOST\" \n\
 \n\
 [home_assistent] \n\
-host = \"$MQTT_BROKER_HOST\"\n\
-username = \"$MQTT_USERNAME\"\n\
-password = \"$MQTT_PASSWORD\"\n" > /usr/local/bin/config.toml
+host = \"$MQTT_BROKER_HOST\"\n"
+
+# Write mqtt broker username if specified
+if [[ -n "$MQTT_USERNAME" ]]; then
+  echo "username = \"$MQTT_USERNAME\"\n" >> /usr/local/bin/config.toml
+fi
+
+# Write mqtt broker password if specified
+if [[ -n "$MQTT_PASSWORD" ]]; then
+  echo "password = \"$MQTT_PASSWORD\"\n" >> /usr/local/bin/config.toml
+fi
+
+# Write port if specified
 if [[ -n "$MQTT_PORT" ]]; then
   echo "port = $MQTT_PORT\n" >> /usr/local/bin/config.toml
 fi

--- a/ha-hoymiles-wifi-addon/run.sh
+++ b/ha-hoymiles-wifi-addon/run.sh
@@ -41,5 +41,16 @@ if [[ -z "$MQTT_PASSWORD" ]]; then
   exit 1
 fi
 
-# Execute the application with the configuration
-/usr/local/bin/hms-mqtt-publish "$INVERTER_HOST" "$MQTT_BROKER_HOST" "$MQTT_USERNAME" "$MQTT_PASSWORD" "$MQTT_PORT"
+# Write configuration to config.toml
+echo "inverter_host = \"$INVERTER_HOST\" \n\
+\n\
+[home_assistent] \n\
+host = \"$MQTT_BROKER_HOST\"\n\
+username = \"$MQTT_USERNAME\"\n\
+password = \"$MQTT_PASSWORD\"\n" > /usr/local/bin/config.toml
+if [[ -n "$MQTT_PORT" ]]; then
+  echo "port = $MQTT_PORT\n" >> /usr/local/bin/config.toml
+fi
+
+# Execute the application
+/usr/local/bin/hms-mqtt-publish

--- a/src/inverter.rs
+++ b/src/inverter.rs
@@ -38,7 +38,7 @@ impl<'a> Inverter<'a> {
             info!("Inverter is {new_state:?}");
         }
     }
-    
+
     pub fn update_state(&mut self) -> Option<HMSStateResponse> {
         self.sequence = self.sequence.wrapping_add(1);
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -4,7 +4,6 @@ use chrono::Local;
 use env_logger::Builder;
 use log::LevelFilter;
 
-
 pub(crate) fn init_logger() {
     Builder::new()
         .format(|buf, record| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use protos::hoymiles::RealData;
 #[derive(Debug, Deserialize)]
 struct Config {
     inverter_host: String,
-    home_assistent: Option<MqttConfig>,
+    home_assistant: Option<MqttConfig>,
     simple_mqtt: Option<MqttConfig>,
 }
 
@@ -50,7 +50,7 @@ fn main() {
     let mut inverter = Inverter::new(&config.inverter_host);
 
     let mut output_channels: Vec<Box<dyn MetricCollector>> = Vec::new();
-    if let Some(config) = config.home_assistent {
+    if let Some(config) = config.home_assistant {
         info!("Publishing to Home Assistent");
         output_channels.push(Box::new(Mqtt::new(&config)));
     }

--- a/src/metric_collector.rs
+++ b/src/metric_collector.rs
@@ -1,0 +1,5 @@
+use crate::protos::hoymiles::RealData::HMSStateResponse;
+
+pub trait MetricCollector {
+    fn publish(&mut self, hms_state: &HMSStateResponse);
+}

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -56,7 +56,7 @@ impl Mqtt {
         // configs let home assistant know what sensors are available and where to find them
         for sensor_config in sensor_configs {
             let config_topic = format!("{}/{}/config", config_topic, sensor_config.unique_id);
-            let config_payload = serde_json::to_value(&sensor_config).unwrap();
+            let config_payload = serde_json::to_value(sensor_config).unwrap();
             self.publish_json(&config_topic, config_payload);
         }
     }
@@ -86,7 +86,7 @@ impl MetricCollector for Mqtt {
 impl HMSStateResponse {
     fn get_model(&self) -> String {
         // TODO: figure out a way to properly identify the model
-        format!("HMS-WiFi")
+        "HMS-WiFi".to_string()
     }
 
     fn get_name(&self) -> String {

--- a/src/mqtt_config.rs
+++ b/src/mqtt_config.rs
@@ -1,0 +1,9 @@
+use serde_derive::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct MqttConfig {
+    pub host: String,
+    pub port: Option<u16>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+}

--- a/src/mqtt_schemas.rs
+++ b/src/mqtt_schemas.rs
@@ -1,19 +1,16 @@
-
 use serde::Serialize;
-
 
 /// `DeviceConfig` is used to define the configuration for a Home Assistant device
 /// in the MQTT discovery protocol and is used to group entities together.
-/// 
+///
 #[derive(Serialize, Clone)]
 pub struct DeviceConfig {
     name: String,
     model: String,
     identifiers: Vec<String>,
     manufacturer: String,
-    sw_version: String,  // Software version of the application that supplies the discovered MQTT item.
+    sw_version: String, // Software version of the application that supplies the discovered MQTT item.
 }
-
 
 impl DeviceConfig {
     pub fn new(name: String, model: String, identifiers: Vec<String>) -> Self {
@@ -22,93 +19,150 @@ impl DeviceConfig {
             model,
             identifiers,
             manufacturer: "Hoymiles".to_string(),
-            // Rust compiler sets the CARGO_PKG_VERSION environment from the Cargo.toml . 
+            // Rust compiler sets the CARGO_PKG_VERSION environment from the Cargo.toml .
             sw_version: env!("CARGO_PKG_VERSION").to_string(),
         }
     }
 }
 
-
 /// `SensorConfig` is used to define the configuration for a Home Assistant sensor entity
 /// in the MQTT discovery protocol.
-/// 
+///
 /// More information about the MQTT discovery protocol can be found here:
 /// https://www.home-assistant.io/docs/mqtt/discovery/
-/// 
+///
 /// More information about the Home assistant sensor entities can be found here:
 /// https://developers.home-assistant.io/docs/core/entity/sensor/
 ///
 #[derive(Serialize)]
 pub struct SensorConfig {
-    pub unique_id: String, //  A globally unique identifier for the sensor.
-    name: String,  // The name of the sensor.
-    state_topic: String, // The MQTT topic where sensor readings will be published.
+    pub unique_id: String,  //  A globally unique identifier for the sensor.
+    name: String,           // The name of the sensor.
+    state_topic: String,    // The MQTT topic where sensor readings will be published.
     value_template: String, // A template to extract a value from the mqtt message.
-    device: DeviceConfig,  // The device that the sensor belongs to, used to group entities together.
+    device: DeviceConfig, // The device that the sensor belongs to, used to group entities together.
     // exclude optional if they are not provided
     #[serde(skip_serializing_if = "Option::is_none")]
-    unit_of_measurement: Option<String>,  // The unit of measurement of the sensor.
+    unit_of_measurement: Option<String>, // The unit of measurement of the sensor.
     #[serde(skip_serializing_if = "Option::is_none")]
-    device_class: Option<String>,  // The type/class of the sensor, e.g. energy, power, temperature, etc.
+    device_class: Option<String>, // The type/class of the sensor, e.g. energy, power, temperature, etc.
 }
-
 
 impl SensorConfig {
     pub fn new_sensor(
-        state_topic: &str, device_config: &DeviceConfig, unique_id: &str, name: &str, 
-        device_class: Option<String>, unit_of_measurement: Option<String>
+        state_topic: &str,
+        device_config: &DeviceConfig,
+        unique_id: &str,
+        name: &str,
+        device_class: Option<String>,
+        unit_of_measurement: Option<String>,
     ) -> Self {
         let value_template = format!("{{{{ value_json.{} }}}}", unique_id);
         let unique_id = format!("{}_{}", device_config.identifiers[0], unique_id);
         SensorConfig {
-            unique_id, 
+            unique_id,
             name: name.to_string(),
             state_topic: state_topic.to_string(),
             unit_of_measurement,
             device_class,
             value_template,
-            device: device_config.clone()
+            device: device_config.clone(),
         }
     }
 
-    pub fn string(state_topic: &str, device_config: &DeviceConfig,  name: &str, key: &str) -> Self {
-        Self::new_sensor(state_topic, &device_config, key, name, 
-            None, None)
+    pub fn string(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
+        Self::new_sensor(state_topic, &device_config, key, name, None, None)
     }
 
-    pub fn power(state_topic: &str, device_config: &DeviceConfig,  name: &str, key: &str) -> Self {
-        Self::new_sensor(state_topic, &device_config, key, name, 
-            Some("power".to_string()), Some("W".to_string()))
+    pub fn power(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
+        Self::new_sensor(
+            state_topic,
+            &device_config,
+            key,
+            name,
+            Some("power".to_string()),
+            Some("W".to_string()),
+        )
     }
 
-    pub fn energy(state_topic: &str, device_config: &DeviceConfig,  name: &str, key: &str) -> Self {
-        Self::new_sensor(state_topic, &device_config, key, name, 
-            Some("energy".to_string()), Some("Wh".to_string()))
+    pub fn energy(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
+        Self::new_sensor(
+            state_topic,
+            &device_config,
+            key,
+            name,
+            Some("energy".to_string()),
+            Some("Wh".to_string()),
+        )
     }
 
-    pub fn voltage(state_topic: &str, device_config: &DeviceConfig,  name: &str, key: &str) -> Self {
-        Self::new_sensor(state_topic, &device_config, key, name, 
-            Some("voltage".to_string()), Some("V".to_string()))
+    pub fn voltage(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
+        Self::new_sensor(
+            state_topic,
+            &device_config,
+            key,
+            name,
+            Some("voltage".to_string()),
+            Some("V".to_string()),
+        )
     }
 
-    pub fn current(state_topic: &str, device_config: &DeviceConfig,  name: &str, key: &str) -> Self {
-        Self::new_sensor(state_topic, &device_config, key, name, 
-            Some("current".to_string()), Some("A".to_string()))
+    pub fn current(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
+        Self::new_sensor(
+            state_topic,
+            &device_config,
+            key,
+            name,
+            Some("current".to_string()),
+            Some("A".to_string()),
+        )
     }
 
-    pub fn temperature(state_topic: &str, device_config: &DeviceConfig,  name: &str, key: &str) -> Self {
-        Self::new_sensor(state_topic, &device_config, key, name, 
-            Some("temperature".to_string()), Some("°C".to_string()))
+    pub fn temperature(
+        state_topic: &str,
+        device_config: &DeviceConfig,
+        name: &str,
+        key: &str,
+    ) -> Self {
+        Self::new_sensor(
+            state_topic,
+            &device_config,
+            key,
+            name,
+            Some("temperature".to_string()),
+            Some("°C".to_string()),
+        )
     }
 
-    pub fn efficiency(state_topic: &str, device_config: &DeviceConfig,  name: &str, key: &str) -> Self {
-        Self::new_sensor(state_topic, &device_config, key, name, 
-            None, Some("%".to_string()))
+    pub fn efficiency(
+        state_topic: &str,
+        device_config: &DeviceConfig,
+        name: &str,
+        key: &str,
+    ) -> Self {
+        Self::new_sensor(
+            state_topic,
+            &device_config,
+            key,
+            name,
+            None,
+            Some("%".to_string()),
+        )
     }
 
-    pub fn frequency(state_topic: &str, device_config: &DeviceConfig,  name: &str, key: &str) -> Self {
-        Self::new_sensor(state_topic, &device_config, key, name, 
-            Some("frequency".to_string()), Some("Hz".to_string()))
+    pub fn frequency(
+        state_topic: &str,
+        device_config: &DeviceConfig,
+        name: &str,
+        key: &str,
+    ) -> Self {
+        Self::new_sensor(
+            state_topic,
+            &device_config,
+            key,
+            name,
+            Some("frequency".to_string()),
+            Some("Hz".to_string()),
+        )
     }
-
 }

--- a/src/mqtt_schemas.rs
+++ b/src/mqtt_schemas.rs
@@ -71,13 +71,13 @@ impl SensorConfig {
     }
 
     pub fn string(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
-        Self::new_sensor(state_topic, &device_config, key, name, None, None)
+        Self::new_sensor(state_topic, device_config, key, name, None, None)
     }
 
     pub fn power(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
         Self::new_sensor(
             state_topic,
-            &device_config,
+            device_config,
             key,
             name,
             Some("power".to_string()),
@@ -99,7 +99,7 @@ impl SensorConfig {
     pub fn voltage(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
         Self::new_sensor(
             state_topic,
-            &device_config,
+            device_config,
             key,
             name,
             Some("voltage".to_string()),
@@ -110,7 +110,7 @@ impl SensorConfig {
     pub fn current(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
         Self::new_sensor(
             state_topic,
-            &device_config,
+            device_config,
             key,
             name,
             Some("current".to_string()),
@@ -126,7 +126,7 @@ impl SensorConfig {
     ) -> Self {
         Self::new_sensor(
             state_topic,
-            &device_config,
+            device_config,
             key,
             name,
             Some("temperature".to_string()),
@@ -142,7 +142,7 @@ impl SensorConfig {
     ) -> Self {
         Self::new_sensor(
             state_topic,
-            &device_config,
+            device_config,
             key,
             name,
             None,
@@ -158,7 +158,7 @@ impl SensorConfig {
     ) -> Self {
         Self::new_sensor(
             state_topic,
-            &device_config,
+            device_config,
             key,
             name,
             Some("frequency".to_string()),

--- a/src/mqtt_schemas.rs
+++ b/src/mqtt_schemas.rs
@@ -46,6 +46,8 @@ pub struct SensorConfig {
     unit_of_measurement: Option<String>, // The unit of measurement of the sensor.
     #[serde(skip_serializing_if = "Option::is_none")]
     device_class: Option<String>, // The type/class of the sensor, e.g. energy, power, temperature, etc.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state_class: Option<String>, // The type/class of the state, e.g. measurement, total_increasing, etc.
 }
 
 impl SensorConfig {
@@ -56,6 +58,7 @@ impl SensorConfig {
         name: &str,
         device_class: Option<String>,
         unit_of_measurement: Option<String>,
+        state_class: Option<String>,
     ) -> Self {
         let value_template = format!("{{{{ value_json.{} }}}}", unique_id);
         let unique_id = format!("{}_{}", device_config.identifiers[0], unique_id);
@@ -67,11 +70,12 @@ impl SensorConfig {
             device_class,
             value_template,
             device: device_config.clone(),
+            state_class,
         }
     }
 
     pub fn string(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
-        Self::new_sensor(state_topic, device_config, key, name, None, None)
+        Self::new_sensor(state_topic, device_config, key, name, None, None, None)
     }
 
     pub fn power(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
@@ -82,17 +86,19 @@ impl SensorConfig {
             name,
             Some("power".to_string()),
             Some("W".to_string()),
+            Some("measurement".to_string()),
         )
     }
 
     pub fn energy(state_topic: &str, device_config: &DeviceConfig, name: &str, key: &str) -> Self {
         Self::new_sensor(
             state_topic,
-            &device_config,
+            device_config,
             key,
             name,
             Some("energy".to_string()),
             Some("Wh".to_string()),
+            Some("total_increasing".to_string()),
         )
     }
 
@@ -104,6 +110,7 @@ impl SensorConfig {
             name,
             Some("voltage".to_string()),
             Some("V".to_string()),
+            Some("measurement".to_string()),
         )
     }
 
@@ -115,6 +122,7 @@ impl SensorConfig {
             name,
             Some("current".to_string()),
             Some("A".to_string()),
+            Some("measurement".to_string()),
         )
     }
 
@@ -131,6 +139,7 @@ impl SensorConfig {
             name,
             Some("temperature".to_string()),
             Some("°C".to_string()),
+            Some("measurement".to_string()),
         )
     }
 
@@ -147,6 +156,7 @@ impl SensorConfig {
             name,
             None,
             Some("%".to_string()),
+            Some("measurement".to_string()),
         )
     }
 
@@ -163,6 +173,7 @@ impl SensorConfig {
             name,
             Some("frequency".to_string()),
             Some("Hz".to_string()),
+            Some("measurement".to_string()),
         )
     }
 }

--- a/src/simple_mqtt.rs
+++ b/src/simple_mqtt.rs
@@ -46,29 +46,60 @@ impl MetricCollector for SimpleMqtt {
     fn publish(&mut self, hms_state: &HMSStateResponse) {
         debug!("{hms_state}");
 
+        self.client.subscribe("hms800wt2", QoS::AtMostOnce).unwrap();
+
         let pv_current_power = hms_state.pv_current_power as f32 / 10.;
         let pv_daily_yield = hms_state.pv_daily_yield;
+        let pv_grid_voltage = hms_state.inverter_state[0].grid_voltage as f32 / 10.;
+        let pv_grid_freq = hms_state.inverter_state[0].grid_freq as f32 / 100.;
+        let pv_inv_temperature = hms_state.inverter_state[0].temperature as f32 / 10.;
+        let pv_port1_voltage = hms_state.port_state[0].pv_vol as f32 / 10.;
+        let pv_port1_curr = hms_state.port_state[0].pv_cur as f32 / 100.;
+        let pv_port1_power = hms_state.port_state[0].pv_power as f32 / 10.;
+        let pv_port1_energy = hms_state.port_state[0].pv_energy_total as f32 / 10.;
+        let pv_port1_daily_yield = hms_state.port_state[0].pv_daily_yield as f32 / 10.;
+        let pv_port2_voltage = hms_state.port_state[1].pv_vol as f32 / 10.;
+        let pv_port2_curr = hms_state.port_state[1].pv_cur as f32 / 100.;
+        let pv_port2_power = hms_state.port_state[1].pv_power as f32 / 10.;
+        let pv_port2_energy = hms_state.port_state[1].pv_energy_total as f32 / 10.;
+        let pv_port2_daily_yield = hms_state.port_state[1].pv_daily_yield as f32 / 10.;
 
-        self.client
-            .subscribe("hms800wt2/pv_current_power", QoS::AtMostOnce)
-            .unwrap();
-        match self.client.publish(
-            "hms800wt2/pv_current_power",
-            QoS::AtMostOnce,
-            true,
-            pv_current_power.to_string(),
-        ) {
-            Ok(_) => {}
-            Err(e) => warn!("mqtt error: {e}"),
-        }
-        match self.client.publish(
-            "hms800wt2/pv_daily_yield",
-            QoS::AtMostOnce,
-            true,
-            pv_daily_yield.to_string(),
-        ) {
-            Ok(_) => {}
-            Err(e) => warn!("mqtt error: {e}"),
-        }
+        // TODO: this section bears a lot of repetition. Investigate if there's a more idiomatic way to get the same result, perhaps using a macro
+        let topic_payload_pairs = [
+            ("hms800wt2/pv_current_power", pv_current_power.to_string()),
+            ("hms800wt2/pv_daily_yield", pv_daily_yield.to_string()),
+            ("hms800wt2/pv_current_power", pv_current_power.to_string()),
+            ("hms800wt2/pv_daily_yield", pv_daily_yield.to_string()),
+            ("hms800wt2/pv_grid_voltage", pv_grid_voltage.to_string()),
+            ("hms800wt2/pv_grid_freq", pv_grid_freq.to_string()),
+            (
+                "hms800wt2/pv_inv_temperature",
+                pv_inv_temperature.to_string(),
+            ),
+            ("hms800wt2/pv_port1_voltage", pv_port1_voltage.to_string()),
+            ("hms800wt2/pv_port1_curr", pv_port1_curr.to_string()),
+            ("hms800wt2/pv_port1_power", pv_port1_power.to_string()),
+            ("hms800wt2/pv_port1_energy", pv_port1_energy.to_string()),
+            (
+                "hms800wt2/pv_port1_daily_yield",
+                pv_port1_daily_yield.to_string(),
+            ),
+            ("hms800wt2/pv_port2_voltage", pv_port2_voltage.to_string()),
+            ("hms800wt2/pv_port2_curr", pv_port2_curr.to_string()),
+            ("hms800wt2/pv_port2_power", pv_port2_power.to_string()),
+            ("hms800wt2/pv_port2_energy", pv_port2_energy.to_string()),
+            (
+                "hms800wt2/pv_port2_daily_yield",
+                pv_port2_daily_yield.to_string(),
+            ),
+        ];
+
+        topic_payload_pairs
+            .into_iter()
+            .for_each(|(topic, payload)| {
+                if let Err(e) = self.client.publish(topic, QoS::AtMostOnce, true, payload) {
+                    warn!("mqtt error: {e}")
+                }
+            });
     }
 }

--- a/src/simple_mqtt.rs
+++ b/src/simple_mqtt.rs
@@ -1,0 +1,74 @@
+use std::{thread, time::Duration};
+
+use crate::{
+    metric_collector::MetricCollector, mqtt_config::MqttConfig,
+    protos::hoymiles::RealData::HMSStateResponse,
+};
+
+use log::{debug, warn};
+use rumqttc::{Client, MqttOptions, QoS};
+
+pub struct SimpleMqtt {
+    client: Client,
+}
+
+impl SimpleMqtt {
+    pub fn new(config: &MqttConfig) -> Self {
+        let mut mqttoptions = MqttOptions::new(
+            "hms800wt2-mqtt-publisher",
+            &config.host,
+            config.port.unwrap_or(1883),
+        );
+        mqttoptions.set_keep_alive(Duration::from_secs(5));
+
+        //parse the mqtt authentication options
+        if let Some((username, password)) = match (&config.username, &config.password) {
+            (None, None) => None,
+            (None, Some(_)) => None,
+            (Some(username), None) => Some((username.clone(), "".into())),
+            (Some(username), Some(password)) => Some((username.clone(), password.clone())),
+        } {
+            mqttoptions.set_credentials(username, password);
+        }
+
+        let (client, mut connection) = Client::new(mqttoptions, 10);
+
+        thread::spawn(move || {
+            // keep polling the event loop to make sure outgoing messages get sent
+            for _ in connection.iter() {}
+        });
+
+        Self { client }
+    }
+}
+
+impl MetricCollector for SimpleMqtt {
+    fn publish(&mut self, hms_state: &HMSStateResponse) {
+        debug!("{hms_state}");
+
+        let pv_current_power = hms_state.pv_current_power as f32 / 10.;
+        let pv_daily_yield = hms_state.pv_daily_yield;
+
+        self.client
+            .subscribe("hms800wt2/pv_current_power", QoS::AtMostOnce)
+            .unwrap();
+        match self.client.publish(
+            "hms800wt2/pv_current_power",
+            QoS::AtMostOnce,
+            true,
+            pv_current_power.to_string(),
+        ) {
+            Ok(_) => {}
+            Err(e) => warn!("mqtt error: {e}"),
+        }
+        match self.client.publish(
+            "hms800wt2/pv_daily_yield",
+            QoS::AtMostOnce,
+            true,
+            pv_daily_yield.to_string(),
+        ) {
+            Ok(_) => {}
+            Err(e) => warn!("mqtt error: {e}"),
+        }
+    }
+}


### PR DESCRIPTION
This PR is an experimental implementation of output channels as defined in a `config.toml` file that allow publishing inverter state to more that one target.