### PR TITLE
Drop dependency on clap crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4.31"
-clap = { version = "4.4.8", features = ["derive"] }
 crc16 = "0.4.0"
 env_logger = "0.10.1"
 log = "0.4.20"


### PR DESCRIPTION
- [x] run `cargo clippy` and fix all issues
- [x] run `cargo fmt` to format all source files
