### PR TITLE
Don't filter logging output

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,20 +1,5 @@
-use std::io::Write;
-
-use chrono::Local;
-use env_logger::Builder;
-use log::LevelFilter;
+use env_logger::{Builder, Env};
 
 pub fn init_logger() {
-    Builder::new()
-        .format(|buf, record| {
-            writeln!(
-                buf,
-                "{} [{}] - {}",
-                Local::now().format("%Y-%m-%dT%H:%M:%S"),
-                record.level(),
-                record.args()
-            )
-        })
-        .filter(None, LevelFilter::Info)
-        .init();
+    Builder::from_env(Env::default().default_filter_or("info")).init();
 }


### PR DESCRIPTION
- [x] run `cargo clippy` and fix all issues
- [x] run `cargo fmt` to format all source files
