### PR TITLE
Unique client ids

### DIFF
--- a/hms2mqtt/src/home_assistant.rs
+++ b/hms2mqtt/src/home_assistant.rs
@@ -23,7 +23,7 @@ impl<MQTT: MqttWrapper> HomeAssistant<MQTT> {
         let payload = serde_json::to_string(&payload).unwrap();
         if let Err(e) =
             self.client
-                .publish(topic, crate::mqtt_wrapper::QoS::ExactlyOnce, true, payload)
+                .publish(topic, crate::mqtt_wrapper::QoS::AtMostOnce, true, payload)
         {
             error!("Failed to publish message: {e:?}");
         }

--- a/hms2mqtt/src/home_assistant.rs
+++ b/hms2mqtt/src/home_assistant.rs
@@ -13,7 +13,7 @@ pub struct HomeAssistant<MQTT: MqttWrapper> {
 
 impl<MQTT: MqttWrapper> HomeAssistant<MQTT> {
     pub fn new(config: &MqttConfig) -> Self {
-        let client = MQTT::new(config);
+        let client = MQTT::new(config, "-ha");
         Self { client }
     }
 

--- a/hms2mqtt/src/mqtt_wrapper.rs
+++ b/hms2mqtt/src/mqtt_wrapper.rs
@@ -22,5 +22,5 @@ pub trait MqttWrapper {
         S: Clone + Into<String>,
         V: Clone + Into<Vec<u8>>;
 
-    fn new(config: &MqttConfig) -> Self;
+    fn new(config: &MqttConfig, suffix: &str) -> Self;
 }

--- a/hms2mqtt/src/simple_mqtt.rs
+++ b/hms2mqtt/src/simple_mqtt.rs
@@ -16,7 +16,7 @@ pub struct SimpleMqtt<MQTT: MqttWrapper> {
 
 impl<MQTT: MqttWrapper> SimpleMqtt<MQTT> {
     pub fn new(config: &MqttConfig) -> Self {
-        let client = MQTT::new(config);
+        let client = MQTT::new(config, "-sm");
         Self { client }
     }
 }

--- a/hms2mqtt/src/simple_mqtt.rs
+++ b/hms2mqtt/src/simple_mqtt.rs
@@ -79,7 +79,7 @@ impl<MQTT: MqttWrapper> MetricCollector for SimpleMqtt<MQTT> {
         topic_payload_pairs
             .into_iter()
             .for_each(|(topic, payload)| {
-                if let Err(e) = self.client.publish(topic, QoS::ExactlyOnce, true, payload) {
+                if let Err(e) = self.client.publish(topic, QoS::AtMostOnce, true, payload) {
                     warn!("mqtt error: {e:?}")
                 }
             });

--- a/src/rumqttc_wrapper.rs
+++ b/src/rumqttc_wrapper.rs
@@ -5,7 +5,7 @@ use hms2mqtt::{
     mqtt_wrapper::{self},
 };
 use log::warn;
-use rumqttc::{Client, MqttOptions, QoS::ExactlyOnce};
+use rumqttc::{Client, MqttOptions, QoS::AtMostOnce};
 
 pub struct RumqttcWrapper {
     client: Client,
@@ -84,7 +84,7 @@ impl mqtt_wrapper::MqttWrapper for RumqttcWrapper {
             // once the client unsubs
             for _ in connection.iter() {}
         });
-        if let Err(e) = client.subscribe("hms800wt2", ExactlyOnce) {
+        if let Err(e) = client.subscribe("hms800wt2", AtMostOnce) {
             warn!("subscription to base topic failed: {e}");
         }
         Self { client }

--- a/src/rumqttc_wrapper.rs
+++ b/src/rumqttc_wrapper.rs
@@ -57,9 +57,9 @@ impl mqtt_wrapper::MqttWrapper for RumqttcWrapper {
             .try_publish(topic, match_qos(qos), retain, payload)?)
     }
 
-    fn new(config: &MqttConfig) -> Self {
+    fn new(config: &MqttConfig, suffix: &str) -> Self {
         let mut mqttoptions = MqttOptions::new(
-            "hms800wt2-mqtt-publisher",
+            "hms800wt2-mqtt-publisher".to_string() + suffix,
             &config.host,
             config.port.unwrap_or(1883),
         );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -35,7 +35,7 @@ impl MqttWrapper for MqttTester {
         Ok(())
     }
 
-    fn new(_config: &hms2mqtt::mqtt_config::MqttConfig) -> Self {
+    fn new(_config: &hms2mqtt::mqtt_config::MqttConfig, _suffix: &str) -> Self {
         Self {
             published_values: Vec::new(),
         }
@@ -44,12 +44,15 @@ impl MqttWrapper for MqttTester {
 
 #[test]
 fn publish_one_message() {
-    let mut mqtt = MqttTester::new(&MqttConfig {
-        host: "frob".to_owned(),
-        port: Some(1234),
-        username: None,
-        password: None,
-    });
+    let mut mqtt = MqttTester::new(
+        &MqttConfig {
+            host: "frob".to_owned(),
+            port: Some(1234),
+            username: None,
+            password: None,
+        },
+        "-test",
+    );
     let result = mqtt.publish(
         "foo",
         hms2mqtt::mqtt_wrapper::QoS::AtMostOnce,


### PR DESCRIPTION
- [x] run `cargo clippy` and fix all issues
- [x] run `cargo fmt` to format all source files

---

This should fix repeated error message that unsolicited packages were sent, e.g. `[2023-12-06T10:39:11Z ERROR rumqttc::state] Unsolicited pubrec packet: 54`.