### PR TITLE
fix: correct link to docker hub in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ cargo r
 
 ### Docker
 
-The latest release is directly deployable via a docker image from [DockerHub](https://hub.docker.com/repository/docker/dennisosrm/hms-mqtt-publisher/general). It is built automatically for the following Linux platforms: 
+The latest release is directly deployable via a docker image from [DockerHub](https://hub.docker.com/r/dennisosrm/hms-mqtt-publisher). It is built automatically for the following Linux platforms: 
  - amd64,
  - arm/v7,
  - and arm64.


### PR DESCRIPTION
- [ ] run `cargo clippy` and fix all issues
- [ ] run `cargo fmt` to format all source files
