### PR TITLE
[MINOR] Fix typo in println(.) statement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
 
     let mut output_channels: Vec<Box<dyn MetricCollector>> = Vec::new();
     if let Some(config) = config.home_assistant {
-        info!("Publishing to Home Assistent");
+        info!("Publishing to Home Assistant");
         output_channels.push(Box::new(HomeAssistant::<RumqttcWrapper>::new(&config)));
     }
 


### PR DESCRIPTION
- [x] run `cargo clippy` and fix all issues
- [x] run `cargo fmt` to format all source files
