### PR TITLE
Cooperative Mode for S-Miles cloud with parameter to enable / disable it. Will pause polling the inverter at appropriate times

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 inverter_host = "192.168.4.182"
 update_interval = 30500
+smiles_cooperation = false
 
 [home_assistant]
 host = "192.168.178.250"

--- a/src/bin/hms-mqtt-publish/main.rs
+++ b/src/bin/hms-mqtt-publish/main.rs
@@ -86,9 +86,8 @@ fn main() {
 
     if config.smiles_cooperation.is_some_and(|value| value) {
         info!("S-Miles cloud cooperative mode enabled");
-    }
-    {
-        info!("S-Miles cloud cooperative mode enabled");
+    } else {
+        info!("S-Miles cloud cooperative mode disabled");
     }
 
     loop {

--- a/src/bin/hms-mqtt-publish/main.rs
+++ b/src/bin/hms-mqtt-publish/main.rs
@@ -14,7 +14,7 @@ use rumqttc_wrapper::RumqttcWrapper;
 use serde_derive::Deserialize;
 use std::fs;
 use std::thread;
-use std::time::{SystemTime, UNIX_EPOCH, Duration};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use log::{error, info};
 
@@ -102,7 +102,9 @@ fn main() {
             // This is the time at which the S-Miles update seems to take place
             // Adding some extra time before and after, in which we dont publish
             if minutes_in_current_hour % 15 == 14 {
-                thread::sleep(Duration::from_millis((15 + 60 - seconds_in_current_minute) * 1000));
+                thread::sleep(Duration::from_millis(
+                    (15 + 60 - seconds_in_current_minute) * 1000,
+                ));
             }
         }
 

--- a/src/bin/hms-mqtt-publish/main.rs
+++ b/src/bin/hms-mqtt-publish/main.rs
@@ -84,7 +84,12 @@ fn main() {
         output_channels.push(Box::new(SimpleMqtt::<RumqttcWrapper>::new(&config)));
     }
 
-    if config.smiles_cooperation {
+    if config
+        .smiles_cooperation
+        .is_some_and(|value| value) {
+            info!("S-Miles cloud cooperative mode enabled");
+        }
+    {
         info!("S-Miles cloud cooperative mode enabled");
     }
 

--- a/src/bin/hms-mqtt-publish/main.rs
+++ b/src/bin/hms-mqtt-publish/main.rs
@@ -22,7 +22,7 @@ use log::{error, info};
 struct Config {
     inverter_host: String,
     update_interval: Option<u64>,
-    smiles_cooperation: bool,
+    smiles_cooperation: Option<bool>,
     home_assistant: Option<MqttConfig>,
     simple_mqtt: Option<MqttConfig>,
 }
@@ -84,18 +84,16 @@ fn main() {
         output_channels.push(Box::new(SimpleMqtt::<RumqttcWrapper>::new(&config)));
     }
 
-    if config
-        .smiles_cooperation
-        .is_some_and(|value| value) {
-            info!("S-Miles cloud cooperative mode enabled");
-        }
+    if config.smiles_cooperation.is_some_and(|value| value) {
+        info!("S-Miles cloud cooperative mode enabled");
+    }
     {
         info!("S-Miles cloud cooperative mode enabled");
     }
 
     loop {
         // Do not query the inverter when the S-Miles cloud is about to update
-        if config.smiles_cooperation {
+        if config.smiles_cooperation.is_some_and(|value| value) {
             let now = SystemTime::now();
             let duration_since_epoch = now.duration_since(UNIX_EPOCH).unwrap();
             let seconds_since_epoch = duration_since_epoch.as_secs();


### PR DESCRIPTION
Introduces a flag that disables polling the inverter at the 14th minute of each hour.

Likely fixes #52 more reliably than setting a higher update interval.


- [ ] run `cargo clippy` and fix all issues (command didn't run for me, sorry)
- [x] run `cargo fmt` to format all source files


PS: I am no Rust dev + I have not included the new parameter "smiles_cooperation" anywhere for the docker config, so maybe that still needs to be done.