### PR TITLE
Publish inverter ID via simple_mqtt

### DIFF
--- a/hms2mqtt/src/simple_mqtt.rs
+++ b/hms2mqtt/src/simple_mqtt.rs
@@ -25,6 +25,7 @@ impl<MQTT: MqttWrapper> MetricCollector for SimpleMqtt<MQTT> {
     fn publish(&mut self, hms_state: &HMSStateResponse) {
         debug!("{hms_state}");
 
+        let inverter_id = &hms_state.dtu_sn;
         let d = UNIX_EPOCH + Duration::from_secs(hms_state.time as u64);
         let datetime = DateTime::<Local>::from(d);
         let inverter_local_time = datetime.format("%Y-%m-%d %H:%M:%S.%f").to_string();
@@ -47,6 +48,7 @@ impl<MQTT: MqttWrapper> MetricCollector for SimpleMqtt<MQTT> {
 
         // TODO: this section bears a lot of repetition. Investigate if there's a more idiomatic way to get the same result, perhaps using a macro
         let topic_payload_pairs = [
+            ("hms800wt2/inverter_id", inverter_id.to_string()),
             ("hms800wt2/inverter_local_time", inverter_local_time),
             ("hms800wt2/pv_current_power", pv_current_power.to_string()),
             ("hms800wt2/pv_daily_yield", pv_daily_yield.to_string()),

--- a/hms2mqtt/src/simple_mqtt.rs
+++ b/hms2mqtt/src/simple_mqtt.rs
@@ -25,7 +25,7 @@ impl<MQTT: MqttWrapper> MetricCollector for SimpleMqtt<MQTT> {
     fn publish(&mut self, hms_state: &HMSStateResponse) {
         debug!("{hms_state}");
 
-        let inverter_id = &hms_state.dtu_sn;
+        let inverter_id = hms_state.inverter_state[0].inv_id;
         let d = UNIX_EPOCH + Duration::from_secs(hms_state.time as u64);
         let datetime = DateTime::<Local>::from(d);
         let inverter_local_time = datetime.format("%Y-%m-%d %H:%M:%S.%f").to_string();

--- a/hms2mqtt/src/simple_mqtt.rs
+++ b/hms2mqtt/src/simple_mqtt.rs
@@ -25,9 +25,9 @@ impl<MQTT: MqttWrapper> MetricCollector for SimpleMqtt<MQTT> {
     fn publish(&mut self, hms_state: &HMSStateResponse) {
         debug!("{hms_state}");
 
-        let inverter_id = hms_state.inverter_state[0].inv_id;
         let d = UNIX_EPOCH + Duration::from_secs(hms_state.time as u64);
         let datetime = DateTime::<Local>::from(d);
+        let inverter_id = hms_state.inverter_state[0].inv_id;
         let inverter_local_time = datetime.format("%Y-%m-%d %H:%M:%S.%f").to_string();
 
         let pv_current_power = hms_state.pv_current_power as f32 / 10.;


### PR DESCRIPTION
I was wondering why this didn't happen for simple_mqtt, but for Home Assistant it did. It makes sense when you want to push data from multiple identical inverters to a single MQTT server, so you can distinguish between them.

- [x] run `cargo clippy` and fix all issues
- [x] run `cargo fmt` to format all source files
