### PR TITLE
Update ha addons

### DIFF
--- a/.github/workflows/dockerhub-nightly.yml
+++ b/.github/workflows/dockerhub-nightly.yml
@@ -39,9 +39,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ secrets.DOCKER_HUB_REPOSITORY_NIGHTLY }}
+          images: ${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ secrets.DOCKER_HUB_REPOSITORY_NIGHTLY }}-${{ github.ref_name }}
           tags: |
-            type=raw,value=nightly-${{ github.ref_name }}-${{ steps.current_date.outputs.date }}
+            type=raw,value=nightly-${{ steps.current_date.outputs.date }}
             type=raw,value=latest
 
       - name: Build and push Docker image

--- a/ha-hoymiles-wifi-addon-nightly/CHANGELOG.md
+++ b/ha-hoymiles-wifi-addon-nightly/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v0.5]
+Add update interval option
+
 ## [v0.4]
 Bugfixes and improvements
 

--- a/ha-hoymiles-wifi-addon-nightly/Dockerfile
+++ b/ha-hoymiles-wifi-addon-nightly/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM
 
 # Use pre-built image to copy the binary from
-FROM dominikandreas/hms-mqtt-publisher-nightly:nightly-main-20231209 AS builder
+FROM dominikandreas/hms-mqtt-publisher-nightly-main:latest AS builder
 
 FROM $BUILD_FROM
 

--- a/ha-hoymiles-wifi-addon-nightly/README.md
+++ b/ha-hoymiles-wifi-addon-nightly/README.md
@@ -1,6 +1,10 @@
-# Home Assistant Add-on
+# Home Assistant Add-on - Nightly
 
-> Note: this is the nightly version of the add-on that is used for testing.
+> THIS ADDON SHOULD ONLY BE USED FOR TESTING!
+
+> This is the nightly version of the add-on that is used for testing,
+> it references the latest build of the underlying rust application
+> and may not always work.
 
 This tool can directly run inside Home Assistant OS as an addon. To get started, add the URL of this repository to the add-on store in Home Assistant and install the add-on. Alternatively, you can also run it stand-alone on any machine that supports rust or docker (see section below).
 

--- a/ha-hoymiles-wifi-addon-nightly/README.md
+++ b/ha-hoymiles-wifi-addon-nightly/README.md
@@ -22,7 +22,7 @@ The following mqtt options can be acquired via the home assistant API if availab
 - `mqtt_port`: The port of your MQTT broker (default is 1883 for unencrypted MQTT).
 
 The update_interval setting controls the frequency of the updates. This should not be
-set to a value less than 30 seconds (see limitations below).
+set to a value less than 30 seconds (see limitations below), any smaller values will be ignored.
 
 - `update_interval: 30500`: The interval in milliseconds between updates.
 
@@ -43,6 +43,6 @@ Please note: The tool does not come with any guarantees and if by chance you fry
 
 ## Known limitations
 
-- One can only fetch updates approximately twice per minute. The inverter firmware seems to implement a mandatory wait period of a little more than 30 seconds. If one makes a request within 30 seconds of the previous one, then the inverter will reply with the previous reading and restart the countdown. It will also not send updated values to S-Miles Cloud if this happens. 
+- One can only fetch updates approximately twice per minute. The inverter firmware seems to implement a mandatory wait period of a little more than 30 seconds. If one makes a request within 30 seconds of the previous one, the inverter will reply with the previous reading and restart the countdown. It will also not send updated values to S-Miles Cloud if this happens.
 
 - The tools was developed for (and with an) HMS-800W-T2. It may work with the other inverters from the series, but is untested at the time of writing

--- a/ha-hoymiles-wifi-addon-nightly/README.md
+++ b/ha-hoymiles-wifi-addon-nightly/README.md
@@ -17,14 +17,14 @@ To set up the add-on, fill in the IP of the inverter host:
 The following mqtt options can be acquired via the home assistant API if available:
 
 - `mqtt_broker_host`: The hostname or IP address of your MQTT broker.
-- `mqtt_username`: The username for your MQTT broker ()
+- `mqtt_username`: The username for your MQTT broker.
 - `mqtt_password`: The password for your MQTT broker. Keep this secret!
 - `mqtt_port`: The port of your MQTT broker (default is 1883 for unencrypted MQTT).
 
 The update_interval setting controls the frequency of the updates. This should not be
 set to a value less than 30 seconds (see limitations below), any smaller values will be ignored.
 
-- `update_interval: 30500`: The interval in milliseconds between updates.
+- `update_interval: 60500`: The interval in milliseconds between updates.
 
 ## Example configuration
 

--- a/ha-hoymiles-wifi-addon-nightly/README.md
+++ b/ha-hoymiles-wifi-addon-nightly/README.md
@@ -10,13 +10,21 @@ This tool can directly run inside Home Assistant OS as an addon. To get started,
 
 ## Configuration
 
-To set up the add-on, fill in the following configuration parameters:
+To set up the add-on, fill in the IP of the inverter host:
 
 - `inverter_host`: The hostname or IP address of your inverter.
+
+The following mqtt options can be acquired via the home assistant API if available:
+
 - `mqtt_broker_host`: The hostname or IP address of your MQTT broker.
-- `mqtt_username`: The username for your MQTT broker.
+- `mqtt_username`: The username for your MQTT broker ()
 - `mqtt_password`: The password for your MQTT broker. Keep this secret!
 - `mqtt_port`: The port of your MQTT broker (default is 1883 for unencrypted MQTT).
+
+The update_interval setting controls the frequency of the updates. This should not be
+set to a value less than 30 seconds (see limitations below).
+
+- `update_interval: 30500`: The interval in milliseconds between updates.
 
 ## Example configuration
 
@@ -26,12 +34,15 @@ mqtt_broker_host: "core-mosquitto"
 mqtt_username: "yourusername"
 mqtt_password: "yourpassword"
 mqtt_port: 1883
+update_interval: 30500
 ```
 
 ## Note of caution
-Please note: The tool does not come with any guarantees and if by chance you fry your inverter with a funny series of bits, you are on your own. That being said, no inverters have been harmed during development. 
+
+Please note: The tool does not come with any guarantees and if by chance you fry your inverter with a funny series of bits, you are on your own. That being said, no inverters have been harmed during development.
 
 ## Known limitations
-- One can only fetch updates approximately twice per minute. The inverter firmware seems to implement a mandatory wait period of a little more than 30 seconds. If one makes a request within 30 seconds of the previous one, then the inverter will reply with the previous reading and restart the countdown. It will also not send updated values to S-Miles Cloud if this happens. 
-- The tools was developed for (and with an) HMS-800W-T2. It may work with the other inverters from the series, but is untested at the time of writing
 
+- One can only fetch updates approximately twice per minute. The inverter firmware seems to implement a mandatory wait period of a little more than 30 seconds. If one makes a request within 30 seconds of the previous one, then the inverter will reply with the previous reading and restart the countdown. It will also not send updated values to S-Miles Cloud if this happens. 
+
+- The tools was developed for (and with an) HMS-800W-T2. It may work with the other inverters from the series, but is untested at the time of writing

--- a/ha-hoymiles-wifi-addon-nightly/config.yaml
+++ b/ha-hoymiles-wifi-addon-nightly/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Hoymiles HMS Wifi Addon (Nightly)
-version: 'v0.4'
+version: 'v0.5'
 slug: ha-hoymiles-wifi-addon-nightly
 description: Publishes telemetry information from Hoymiles HMS-XXXXW-T2 micro-inverters to your home assistant MQTT broker
 url: https://github.com/dominikandreas/hms-mqtt-publisher/tree/main/ha-hoymiles-wifi-addon-nightly

--- a/ha-hoymiles-wifi-addon-nightly/config.yaml
+++ b/ha-hoymiles-wifi-addon-nightly/config.yaml
@@ -18,6 +18,7 @@ options:                          # Default options value for the add-on.
   mqtt_username: ''
   mqtt_password: ''
   mqtt_port: 1883
+  update_interval: 30500
   debug_logging: false
 schema:                            # Schema validation for the options.
   inverter_host: str
@@ -25,4 +26,5 @@ schema:                            # Schema validation for the options.
   mqtt_username: str?
   mqtt_password: str?
   mqtt_port: int
+  update_interval: int
   debug_logging: bool

--- a/ha-hoymiles-wifi-addon-nightly/config.yaml
+++ b/ha-hoymiles-wifi-addon-nightly/config.yaml
@@ -18,7 +18,7 @@ options:                          # Default options value for the add-on.
   mqtt_username: ''
   mqtt_password: ''
   mqtt_port: 1883
-  update_interval: 30500
+  update_interval: 60500
   debug_logging: false
 schema:                            # Schema validation for the options.
   inverter_host: str

--- a/ha-hoymiles-wifi-addon-nightly/run.sh
+++ b/ha-hoymiles-wifi-addon-nightly/run.sh
@@ -25,21 +25,21 @@ DEBUG_LOGGING=${DEBUG_LOGGING:-'false'}
 
 # Check if the required configs are provided
 if [[ -z "$INVERTER_HOST" ]]; then
-  echo "The inverter_host is not configured."
-  exit 1
+    echo "The inverter_host is not configured."
+    exit 1
 fi
 
 if [[ -z "$MQTT_BROKER_HOST" ]]; then
-  echo "The mqtt_broker_host is not configured."
-  exit 1
+    echo "The mqtt_broker_host is not configured."
+    exit 1
 fi
 
-# print a warning if update interval is > 30500 
-if [[ "$UPDATE_INTERVAL" -gt 30500 ]]; then
-  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-  echo "The update_interval is set to a value greater than 30500."
-  echo "This is not recommended and may cause the inverter to become unresponsive."
-  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+# print a warning if update interval is < 60500
+if [[ "$UPDATE_INTERVAL" -lt 60500 ]]; then
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo "The update_interval is set to a value lower than 60500."
+    echo "This is not recommended and may cause the inverter to become unresponsive."
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 fi
 
 # Create the configuration file
@@ -56,7 +56,7 @@ EOF
 
 # if DEBUG_LOGGING is true, set the RUST_LOG=debug environment variable to enable debug logging
 if [[ "$DEBUG_LOGGING" == "true" ]]; then
-  export RUST_LOG=debug
+    export RUST_LOG=debug
 fi
 
 # Execute the application

--- a/ha-hoymiles-wifi-addon-nightly/run.sh
+++ b/ha-hoymiles-wifi-addon-nightly/run.sh
@@ -13,6 +13,7 @@ MQTT_BROKER_HOST=$(bashio::config 'mqtt_broker_host')
 MQTT_USERNAME=$(bashio::config 'mqtt_username')
 MQTT_PASSWORD=$(bashio::config 'mqtt_password')
 MQTT_PORT=$(bashio::config 'mqtt_port')
+UPDATE_INTERVAL=$(bashio::config 'update_interval')
 DEBUG_LOGGING=$(bashio::config 'debug_logging')
 
 # Use bashio::config values if they are defined, otherwise fall back to bashio::services values
@@ -33,9 +34,18 @@ if [[ -z "$MQTT_BROKER_HOST" ]]; then
   exit 1
 fi
 
+# print a warning if update interval is > 30500 
+if [[ "$UPDATE_INTERVAL" -gt 30500 ]]; then
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "The update_interval is set to a value greater than 30500."
+  echo "This is not recommended and may cause the inverter to become unresponsive."
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+fi
+
 # Create the configuration file
 cat <<EOF > ./config.toml
 inverter_host = "$INVERTER_HOST"
+update_interval = $UPDATE_INTERVAL
 
 [home_assistant]
 host = "$MQTT_BROKER_HOST"

--- a/ha-hoymiles-wifi-addon/CHANGELOG.md
+++ b/ha-hoymiles-wifi-addon/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v0.5]
+Add update interval option
+Update to v0.4 of the underlying rust application
+
 ## [v0.4]
 Bugfixes and improvements
 

--- a/ha-hoymiles-wifi-addon/README.md
+++ b/ha-hoymiles-wifi-addon/README.md
@@ -11,14 +11,14 @@ To set up the add-on, fill in the IP of the inverter host:
 The following mqtt options can be acquired via the home assistant API if available:
 
 - `mqtt_broker_host`: The hostname or IP address of your MQTT broker.
-- `mqtt_username`: The username for your MQTT broker ()
+- `mqtt_username`: The username for your MQTT broker.
 - `mqtt_password`: The password for your MQTT broker. Keep this secret!
 - `mqtt_port`: The port of your MQTT broker (default is 1883 for unencrypted MQTT).
 
 The update_interval setting controls the frequency of the updates. This should not be
 set to a value less than 30 seconds (see limitations below), any smaller values will be ignored.
 
-- `update_interval: 30500`: The interval in milliseconds between updates.
+- `update_interval: 60500`: The interval in milliseconds between updates.
 
 ## Example configuration
 

--- a/ha-hoymiles-wifi-addon/README.md
+++ b/ha-hoymiles-wifi-addon/README.md
@@ -4,13 +4,21 @@ This tool can directly run inside Home Assistant OS as an addon. To get started,
 
 ## Configuration
 
-To set up the add-on, fill in the following configuration parameters:
+To set up the add-on, fill in the IP of the inverter host:
 
 - `inverter_host`: The hostname or IP address of your inverter.
+
+The following mqtt options can be acquired via the home assistant API if available:
+
 - `mqtt_broker_host`: The hostname or IP address of your MQTT broker.
-- `mqtt_username`: The username for your MQTT broker.
+- `mqtt_username`: The username for your MQTT broker ()
 - `mqtt_password`: The password for your MQTT broker. Keep this secret!
 - `mqtt_port`: The port of your MQTT broker (default is 1883 for unencrypted MQTT).
+
+The update_interval setting controls the frequency of the updates. This should not be
+set to a value less than 30 seconds (see limitations below), any smaller values will be ignored.
+
+- `update_interval: 30500`: The interval in milliseconds between updates.
 
 ## Example configuration
 
@@ -20,12 +28,15 @@ mqtt_broker_host: "core-mosquitto"
 mqtt_username: "yourusername"
 mqtt_password: "yourpassword"
 mqtt_port: 1883
+update_interval: 30500
 ```
 
 ## Note of caution
-Please note: The tool does not come with any guarantees and if by chance you fry your inverter with a funny series of bits, you are on your own. That being said, no inverters have been harmed during development. 
+
+Please note: The tool does not come with any guarantees and if by chance you fry your inverter with a funny series of bits, you are on your own. That being said, no inverters have been harmed during development.
 
 ## Known limitations
-- One can only fetch updates approximately twice per minute. The inverter firmware seems to implement a mandatory wait period of a little more than 30 seconds. If one makes a request within 30 seconds of the previous one, then the inverter will reply with the previous reading and restart the countdown. It will also not send updated values to S-Miles Cloud if this happens. 
-- The tools was developed for (and with an) HMS-800W-T2. It may work with the other inverters from the series, but is untested at the time of writing
 
+- One can only fetch updates approximately twice per minute. The inverter firmware seems to implement a mandatory wait period of a little more than 30 seconds. If one makes a request within 30 seconds of the previous one, the inverter will reply with the previous reading and restart the countdown. It will also not send updated values to S-Miles Cloud if this happens. 
+
+- The tools was developed for (and with an) HMS-800W-T2. It may work with the other inverters from the series, but is untested at the time of writing

--- a/ha-hoymiles-wifi-addon/config.yaml
+++ b/ha-hoymiles-wifi-addon/config.yaml
@@ -1,9 +1,9 @@
 ---
 name: Hoymiles HMS Wifi Addon
-version: 'v0.3'
+version: 'v0.5'
 slug: ha-hoymiles-wifi-addon
 description: Publishes telemetry information from Hoymiles HMS-XXXXW-T2 micro-inverters to your home assistant MQTT broker
-url: https://github.com/dominikandreas/hms-mqtt-publisher/tree/master/ha-hoymiles-wifi-addon
+url: https://github.com/DennisOSRM/hms-mqtt-publisher/tree/master/ha-hoymiles-wifi-addon
 init: false
 arch:                              # List of supported architectures.
   - armv7
@@ -18,6 +18,7 @@ options:                          # Default options value for the add-on.
   mqtt_username: ''
   mqtt_password: ''
   mqtt_port: 1883
+  update_interval: 60500
   debug_logging: false
 schema:                            # Schema validation for the options.
   inverter_host: str
@@ -25,4 +26,5 @@ schema:                            # Schema validation for the options.
   mqtt_username: str?
   mqtt_password: str?
   mqtt_port: int
+  update_interval: int
   debug_logging: bool

--- a/ha-hoymiles-wifi-addon/run.sh
+++ b/ha-hoymiles-wifi-addon/run.sh
@@ -13,6 +13,7 @@ MQTT_BROKER_HOST=$(bashio::config 'mqtt_broker_host')
 MQTT_USERNAME=$(bashio::config 'mqtt_username')
 MQTT_PASSWORD=$(bashio::config 'mqtt_password')
 MQTT_PORT=$(bashio::config 'mqtt_port')
+UPDATE_INTERVAL=$(bashio::config 'update_interval')
 DEBUG_LOGGING=$(bashio::config 'debug_logging')
 
 # Use bashio::config values if they are defined, otherwise fall back to bashio::services values
@@ -24,18 +25,27 @@ DEBUG_LOGGING=${DEBUG_LOGGING:-'false'}
 
 # Check if the required configs are provided
 if [[ -z "$INVERTER_HOST" ]]; then
-  echo "The inverter_host is not configured."
-  exit 1
+    echo "The inverter_host is not configured."
+    exit 1
 fi
 
 if [[ -z "$MQTT_BROKER_HOST" ]]; then
-  echo "The mqtt_broker_host is not configured."
-  exit 1
+    echo "The mqtt_broker_host is not configured."
+    exit 1
+fi
+
+# print a warning if update interval is < 60500
+if [[ "$UPDATE_INTERVAL" -lt 60500 ]]; then
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo "The update_interval is set to a value lower than 60500."
+    echo "This is not recommended and may cause the inverter to become unresponsive."
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 fi
 
 # Create the configuration file
 cat <<EOF > ./config.toml
 inverter_host = "$INVERTER_HOST"
+update_interval = $UPDATE_INTERVAL
 
 [home_assistant]
 host = "$MQTT_BROKER_HOST"
@@ -46,7 +56,7 @@ EOF
 
 # if DEBUG_LOGGING is true, set the RUST_LOG=debug environment variable to enable debug logging
 if [[ "$DEBUG_LOGGING" == "true" ]]; then
-  export RUST_LOG=debug
+    export RUST_LOG=debug
 fi
 
 # Execute the application


### PR DESCRIPTION
Changes:

- update the Home Assistant Addons (nightly and regular) to the latest version of the underlying rust application
- add option in the Home Assistant addon configuration to specify the update interval (defaults to 60500ms to be more on the safe side)
- specify the branch in the name of the image created by nightly build action. this allows to refer to the latest image of a specific branch and is used in the dockerfile for home assistant

The nightly addon currently still specifies my own fork in the dockerfile. This can be changed once the build action of this repo is updated with the changes of this PR.